### PR TITLE
Use NameWithTags for KeyBySeries()

### DIFF
--- a/metric.go
+++ b/metric.go
@@ -229,7 +229,7 @@ func (m *MetricDefinition) KeyByOrgId(b []byte) []byte {
 }
 
 func (m *MetricDefinition) KeyBySeries(b []byte) []byte {
-	b = append(b, []byte(m.Name)...)
+	b = append(b, []byte(m.NameWithTags())...)
 	return b
 }
 


### PR DESCRIPTION
In the future there might be users which rely mostly just on tags to
identify metrics, those would probably set a lot or even all metrics to
the same Name. If we only key by the Name property, then this will lead
to a very unbalanced distribution between partitions.