### PR TITLE
Fix rollup parsing

### DIFF
--- a/key.go
+++ b/key.go
@@ -102,7 +102,7 @@ func AMKeyFromString(s string) (AMKey, error) {
 			return amk, err
 		}
 		span, err := strconv.ParseInt(splits[2], 10, 32)
-		if err == nil {
+		if err != nil {
 			return amk, err
 		}
 		if !IsSpanValid(uint32(span)) {

--- a/key_test.go
+++ b/key_test.go
@@ -38,3 +38,33 @@ func TestMKeyConversionBothWays(t *testing.T) {
 		}
 	}
 }
+
+func TestMKeyConversionBothWaysWithArchive(t *testing.T) {
+
+	cases := []struct {
+		idStr    string
+		expErr   bool
+		expAMKey AMKey
+	}{
+		{".00112233445566778899aabbccd_deeff", true, AMKey{}},
+		{"0.0112233445566778899aab_bccd_deeff", true, AMKey{}},
+		{"0.00112233445566778899aabbccddeeff_min_600", false, AMKey{MKey{[16]byte{0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff}, 0}, NewArchive(Min, 600)}},
+	}
+
+	for i, c := range cases {
+		amk, err := AMKeyFromString(c.idStr)
+		if (err != nil) != c.expErr {
+			t.Fatalf("case %d exp err %v got %v", i, c.expErr, err)
+		}
+		if err != nil {
+			continue
+		}
+		if amk != c.expAMKey {
+			t.Fatalf("case %d exp MKey %v got %v", i, c.expAMKey, amk)
+		}
+		str := amk.String()
+		if str != c.idStr {
+			t.Fatalf("case %d exp MKey.String() %v got %v", i, c.idStr, str)
+		}
+	}
+}

--- a/key_test.go
+++ b/key_test.go
@@ -39,7 +39,7 @@ func TestMKeyConversionBothWays(t *testing.T) {
 	}
 }
 
-func TestMKeyConversionBothWaysWithArchive(t *testing.T) {
+func TestAMKeyConversionBothWays(t *testing.T) {
 
 	cases := []struct {
 		idStr    string
@@ -48,6 +48,7 @@ func TestMKeyConversionBothWaysWithArchive(t *testing.T) {
 	}{
 		{".00112233445566778899aabbccd_deeff", true, AMKey{}},
 		{"0.0112233445566778899aab_bccd_deeff", true, AMKey{}},
+		{"0.00112233445566778899aabbccddeeff", false, AMKey{MKey{[16]byte{0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff}, 0}, 0}},
 		{"0.00112233445566778899aabbccddeeff_min_600", false, AMKey{MKey{[16]byte{0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff}, 0}, NewArchive(Min, 600)}},
 	}
 


### PR DESCRIPTION
This tiny little bug caused our rollup chunks to get clobbered when write instances of metrictank restarted.