### PR TITLE
deprecate gopkg.in

### DIFF
--- a/msg/msg.go
+++ b/msg/msg.go
@@ -8,7 +8,7 @@ import (
 	"fmt"
 	"time"
 
-	"gopkg.in/raintank/schema.v1"
+	"github.com/raintank/schema"
 )
 
 var errTooSmall = errors.New("too small")

--- a/msg/msg_test.go
+++ b/msg/msg_test.go
@@ -5,7 +5,7 @@ import (
 	"reflect"
 	"testing"
 
-	schema "gopkg.in/raintank/schema.v1"
+	"github.com/raintank/schema"
 )
 
 func TestWriteReadPointMsg(t *testing.T) {


### PR DESCRIPTION
importers of this library can better use a proper dependency
management tool such as dep.