### PR TITLE
Make AMKey serializable via string type

### DIFF
--- a/key.go
+++ b/key.go
@@ -14,8 +14,13 @@ import (
 //msgp:ignore AMKey
 // don't ignore Key, MKey because it's used for MetricDefinition
 
+// A random number that does not conflict with any of the msgp internal
+// types, and which is also not the first one after the msgp internal types
+// to avoid accidental conflicts with other custom types
+const msgpExtensionId = 97
+
 func init() {
-	msgp.RegisterExtension(97, func() msgp.Extension { return new(AMKey) })
+	msgp.RegisterExtension(msgpExtensionId, func() msgp.Extension { return new(AMKey) })
 }
 
 var ErrStringTooShort = errors.New("string too short")
@@ -74,10 +79,7 @@ type AMKey struct {
 
 // ExtensionType is part of the msgp.Extension interface
 func (a *AMKey) ExtensionType() int8 {
-	// A random number that does not conflict with any of the msgp internal
-	// types, and which is also not the first one after the msgp internal types
-	// to avoid accidental conflicts with other custom types
-	return 97
+	return msgpExtensionId
 }
 
 // Len is part of the msgp.Extension interface

--- a/key.go
+++ b/key.go
@@ -6,13 +6,19 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+
+	"github.com/tinylib/msgp/msgp"
 )
 
 //go:generate msgp
 //msgp:ignore AMKey
 // don't ignore Key, MKey because it's used for MetricDefinition
 
-var ErrStringTooShort = errors.New("string to short")
+func init() {
+	msgp.RegisterExtension(97, func() msgp.Extension { return new(AMKey) })
+}
+
+var ErrStringTooShort = errors.New("string too short")
 var ErrInvalidFormat = errors.New("invalid format")
 
 // Key identifies a metric
@@ -57,7 +63,6 @@ func MKeyFromString(s string) (MKey, error) {
 
 func (m MKey) String() string {
 	return fmt.Sprintf("%d.%x", m.Org, m.Key)
-
 }
 
 // AMKey is a multi-tenant key with archive extension
@@ -65,6 +70,40 @@ func (m MKey) String() string {
 type AMKey struct {
 	MKey    MKey
 	Archive Archive
+}
+
+// ExtensionType is part of the msgp.Extension interface
+func (a *AMKey) ExtensionType() int8 {
+	// A random number that does not conflict with any of the msgp internal
+	// types, and which is also not the first one after the msgp internal types
+	// to avoid accidental conflicts with other custom types
+	return 97
+}
+
+// Len is part of the msgp.Extension interface
+// It returns the length of the encoded byte slice representing this AMKey
+// Length is variable because the AMKey may include the span & method,
+// also the org id can have a varying number of digits
+func (a *AMKey) Len() int {
+	return len(a.String())
+}
+
+// MarshalBinaryTo is part of the msgp.Extension interface
+// It takes a buffer which must have the length returned by the Len() function
+// and writes the encoded version of this AMKey into it
+func (a *AMKey) MarshalBinaryTo(buf []byte) error {
+	copy(buf, a.String())
+
+	return nil
+}
+
+// UnmarshalBinary is part of the msgp.Extension interface
+// It takes a buffer containing an encoded AMKey and decodes it into this
+// AMKey instance
+func (a *AMKey) UnmarshalBinary(buf []byte) error {
+	var err error
+	*a, err = AMKeyFromString(string(buf))
+	return err
 }
 
 func (a AMKey) String() string {

--- a/method_string.go
+++ b/method_string.go
@@ -4,6 +4,18 @@ package schema
 
 import "strconv"
 
+func _() {
+	// An "invalid array index" compiler error signifies that the constant values have changed.
+	// Re-run the stringer command to generate them again.
+	var x [1]struct{}
+	_ = x[Avg-1]
+	_ = x[Sum-2]
+	_ = x[Lst-3]
+	_ = x[Max-4]
+	_ = x[Min-5]
+	_ = x[Cnt-6]
+}
+
 const _Method_name = "avgsumlstmaxmincnt"
 
 var _Method_index = [...]uint8{0, 3, 6, 9, 12, 15, 18}


### PR DESCRIPTION
Other minor changes:
- Fixes typo in error message
- Updates stringer generated function for agg method

Related: https://github.com/grafana/metrictank/pull/1291