### PR TITLE
Add clone method to MetricDefinition

### DIFF
--- a/metric.go
+++ b/metric.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"sort"
 	"strings"
+	"sync/atomic"
 )
 
 var ErrInvalidIntervalzero = errors.New("interval cannot be 0")
@@ -135,6 +136,23 @@ func (m *MetricDefinition) NameWithTags() string {
 	}
 
 	return m.nameWithTags
+}
+
+// Clone() returns a copy of the MetricDefinition. It uses atomic operations
+// to read certain properties that get updated atomically
+func (m *MetricDefinition) Clone() MetricDefinition {
+	return MetricDefinition{
+		Id:           m.Id,
+		OrgId:        m.OrgId,
+		Name:         m.Name,
+		Interval:     m.Interval,
+		Unit:         m.Unit,
+		Mtype:        m.Mtype,
+		Tags:         m.Tags,
+		LastUpdate:   atomic.LoadInt64(&m.LastUpdate),
+		Partition:    atomic.LoadInt32(&m.Partition),
+		nameWithTags: m.nameWithTags,
+	}
 }
 
 func (m *MetricDefinition) NameSanitizedAsTagValue() string {


### PR DESCRIPTION
This method will be used in Metrictank's `idx.memory.Clone()` function to reduce the allocations that are currently required to regenerate the name with tags when `.NameWithTags()` gets called.

Thx to @shanson7 