### PR TITLE
add function to eat dots

### DIFF
--- a/metric.go
+++ b/metric.go
@@ -244,6 +244,46 @@ func SanitizeNameAsTagValue(name string) string {
 	return ""
 }
 
+// EatDots removes multiple consecutive, leading, and trailing dots
+// from name. If the provided name is only dots, it will return an
+// empty string
+func EatDots(name string) string {
+	if len(name) == 0 {
+		return ""
+	}
+
+	n := strings.Trim(name, ".")
+
+	ln := len(n)
+
+	if ln == 0 {
+		return ""
+	}
+
+	rt := make([]byte, 0, ln)
+
+	for i, s := range n {
+
+		if s == '.' {
+			// since trailing dots are already removed we won't
+			// ever hit an index out of range
+			if n[i+1] == '.' {
+				continue
+			}
+
+			// if this is the last dot in a consecutive series, append it
+			rt = append(rt, '.')
+			continue
+		}
+
+		// if it is not a dot, append it
+		rt = append(rt, byte(s))
+	}
+
+	// return a string representation of our clean byte slice
+	return string(rt)
+}
+
 // ValidateTags returns whether all tags are in a valid format.
 // a valid format is anything that looks like key=value,
 // the length of key and value must be >0 and both cannot contain

--- a/metric.go
+++ b/metric.go
@@ -247,7 +247,7 @@ func SanitizeNameAsTagValue(name string) string {
 // EatDots removes multiple consecutive, leading, and trailing dots
 // from name. If the provided name is only dots, it will return an
 // empty string
-// The wast majority of names will not need to be modified,
+// The vast majority of names will not need to be modified,
 // so we optimize for that case. This function only requires
 // allocations if the name does need to be modified.
 func EatDots(name string) string {

--- a/metric.go
+++ b/metric.go
@@ -247,41 +247,60 @@ func SanitizeNameAsTagValue(name string) string {
 // EatDots removes multiple consecutive, leading, and trailing dots
 // from name. If the provided name is only dots, it will return an
 // empty string
+// The wast majority of names will not need to be modified,
+// so we optimize for that case. This function only requires
+// allocations if the name does need to be modified.
 func EatDots(name string) string {
 	if len(name) == 0 {
 		return ""
 	}
 
-	n := strings.Trim(name, ".")
+	dotsToRemove := 0
+	if name[0] == '.' {
+		dotsToRemove++
+	}
+	for i := 1; i < len(name); i++ {
+		if name[i] == '.' {
+			if name[i-1] == '.' {
+				dotsToRemove++
+			}
+			if i == len(name)-1 {
+				dotsToRemove++
+			}
+		}
+	}
 
-	ln := len(n)
+	// the majority of cases will return here
+	if dotsToRemove == 0 {
+		return name
+	}
 
-	if ln == 0 {
+	if dotsToRemove >= len(name) {
 		return ""
 	}
 
-	rt := make([]byte, 0, ln)
-
-	for i, s := range n {
-
-		if s == '.' {
-			// since trailing dots are already removed we won't
-			// ever hit an index out of range
-			if n[i+1] == '.' {
-				continue
+	newName := make([]byte, len(name)-dotsToRemove)
+	j := 0
+	sawDot := false
+	for i := 0; i < len(name); i++ {
+		if name[i] == '.' {
+			if j > 0 {
+				sawDot = true
 			}
-
-			// if this is the last dot in a consecutive series, append it
-			rt = append(rt, '.')
 			continue
 		}
 
-		// if it is not a dot, append it
-		rt = append(rt, byte(s))
+		if sawDot {
+			newName[j] = '.'
+			sawDot = false
+			j++
+		}
+
+		newName[j] = name[i]
+		j++
 	}
 
-	// return a string representation of our clean byte slice
-	return string(rt)
+	return string(newName)
 }
 
 // ValidateTags returns whether all tags are in a valid format.

--- a/metricpoint_test.go
+++ b/metricpoint_test.go
@@ -6,6 +6,34 @@ import (
 	"testing"
 )
 
+var testMetrics = []string{
+	"some.id.of.a.metric",
+	".some.id.of.a.metric.",
+	"..some.id.of.a.metric",
+	"some.id....of.a.metric",
+	"some.id.of....a..metric",
+	"some...id.of.a.metric..",
+	".",
+	"...",
+	"..a.",
+	"...a",
+	"a...",
+}
+
+var expectedResults = []string{
+	"some.id.of.a.metric",
+	"some.id.of.a.metric",
+	"some.id.of.a.metric",
+	"some.id.of.a.metric",
+	"some.id.of.a.metric",
+	"some.id.of.a.metric",
+	"",
+	"",
+	"a",
+	"a",
+	"a",
+}
+
 func TestMetricPointMarshal(t *testing.T) {
 	tests := []MetricPoint{
 		{
@@ -166,6 +194,31 @@ func TestMetricPointMarshalMultiple(t *testing.T) {
 	for _, check := range checks {
 		if buf[check.pos] != check.val {
 			t.Fatalf("%s: expected val %d, got %d", check.comment, check.val, buf[check.pos])
+		}
+	}
+}
+
+func TestEatDots(t *testing.T) {
+	results := make([]string, 0, len(testMetrics))
+
+	for _, s := range testMetrics {
+		results = append(results, EatDots(s))
+	}
+
+	for i := range results {
+		if results[i] != expectedResults[i] {
+			t.Errorf("Result '%s' does not match expected '%s'", results[i], expectedResults[i])
+		}
+	}
+}
+
+var globalString string
+
+func BenchmarkEatDots(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		for _, s := range testMetrics {
+			globalString = EatDots(s)
 		}
 	}
 }


### PR DESCRIPTION
Adds a function which eats all multiple consecutive dots and removes leading and trailing dots. This does **NOT** implement usage of the function. That should be done in separate pull requests in the respective repositories where it is required.

See also: https://github.com/raintank/tsdb-gw/issues/64 https://github.com/grafana/metrictank/issues/1008 https://github.com/grafana/metrictank/issues/811 https://github.com/graphite-ng/carbon-relay-ng/pull/296